### PR TITLE
Create meeting.html

### DIFF
--- a/meeting.html
+++ b/meeting.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Austin IWW - Meeting Info</title>
+</head>
+<body>
+    <h1>Meeting Info</h1>
+    <h2>Current Schedule</h2>
+        <p>Online meetings are currently held every other Monday @ 8:00 pm.</p>
+        <p>The next general meeting will be held on 4/12</p>
+        <!-- If desired, we can look into changing this into a calendar widget or set up a script that updates the date periodically -->
+
+    <h2>Meeting Minutes</h2>
+        <p>The Minutes for the most recent meeting can be found <a href="https://docs.google.com/document/d/1eJtWCqKKPBL4rBSE2X3z4wnxt-HD5sNDcntnBF_byd8/edit">here</a>.</p>
+        <!-- Alternatively, instead of linking the Meeting Minutes in Google Docs, we can either set up a document file download or place a copy of the meeting minutes document text within the page -->
+
+    <div>
+        <nav>
+            <ul>
+                <li><a href="index.html">Home</a></li>
+                <li><a href="about.html">About</a></li>                    
+                <li><a href="documents.html">Documents</a></li>
+            </ul>
+        </nav>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Barebones HTML for the Meeting info and minutes page with navigation links. "Meeting Info" section is optional and kept minimal for privacy purposes. I am not sure how we would like to set up this page to provide the minutes - do we want to set it up so that viewers can download documentation of the minutes as a file? A link to a Google Doc? Do we want a viewable document embedded in the page itself?